### PR TITLE
Query/2

### DIFF
--- a/src/screen/home/component/TodoEditForm.tsx
+++ b/src/screen/home/component/TodoEditForm.tsx
@@ -5,7 +5,6 @@ import { useParams } from 'react-router-dom';
 import ButtonBasic from '../../../common/components/button/ButtonBasic';
 import InputBasic from '../../../common/components/input/InputBasic';
 import { TodoParams } from '../../../api/Todos/types';
-import useGetTodos from '../hooks/useGetTodos';
 import useGetTodoById from '../hooks/useGetTodoById';
 import useUpdateTodos from '../hooks/useUpdateTodo';
 
@@ -27,7 +26,6 @@ interface TodoEditForm {
 function TodoEditForm({ closeEditMode }: TodoEditForm) {
   const { id: todoId } = useParams();
   const { register, handleSubmit } = useForm<TodoParams>();
-  const { refetch: refetchTodos } = useGetTodos({suspense:true});
   const { data: todoData, refetch: refetchTodo } = useGetTodoById(todoId);
   const { mutate } = useUpdateTodos();
 
@@ -40,9 +38,8 @@ function TodoEditForm({ closeEditMode }: TodoEditForm) {
       return;
     }
     const onSuccess = () => {
-      closeEditMode();
-      refetchTodos();
       refetchTodo();
+      closeEditMode();
     };
     mutate({ id: todoId, params: { title, content } }, { onSuccess });
   };

--- a/src/screen/home/component/TodoListCard.tsx
+++ b/src/screen/home/component/TodoListCard.tsx
@@ -29,11 +29,8 @@ const Container = styled.li`
   }
 `;
 
-interface TodoListCardProps extends Todo {
-  refetchTodos: () => void;
-}
 
-function TodoListCard({ id, title, createdAt, refetchTodos }: TodoListCardProps) {
+function TodoListCard({ id, title, createdAt }: Todo) {
   const { mutate } = useDeleteTodo();
   const { id: currentTodoId } = useParams();
   const navigate = useNavigate();
@@ -51,7 +48,6 @@ function TodoListCard({ id, title, createdAt, refetchTodos }: TodoListCardProps)
         if (isCardSelected()) {
           navigate('/', { replace: true });
         }
-        refetchTodos();
       },
     });
   };

--- a/src/screen/home/hooks/useCreateTodo.ts
+++ b/src/screen/home/hooks/useCreateTodo.ts
@@ -1,9 +1,14 @@
-import { useMutation } from "@tanstack/react-query";
-import { apiTodos } from "../../../api/Todos/todos";
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiTodos } from '../../../api/Todos/todos';
+import { queryKeyGetTodos } from './useGetTodos';
 
-
-function useCreateTodo (){
-  return useMutation(apiTodos.createTodo);
+function useCreateTodo() {
+  const queryClient = useQueryClient();
+  return useMutation(apiTodos.createTodo, {
+    onSuccess: () => {
+      queryClient.invalidateQueries([...queryKeyGetTodos]);
+    },
+  });
 }
 
-export default useCreateTodo
+export default useCreateTodo;

--- a/src/screen/home/hooks/useDeleteTodo.ts
+++ b/src/screen/home/hooks/useDeleteTodo.ts
@@ -1,8 +1,14 @@
-import { useMutation } from "@tanstack/react-query";
-import { apiTodos } from "../../../api/Todos/todos";
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiTodos } from '../../../api/Todos/todos';
+import { queryKeyGetTodos } from './useGetTodos';
 
-function useDeleteTodo () {
-  return useMutation(apiTodos.deleteTodo)
+function useDeleteTodo() {
+  const queryClient = useQueryClient();
+  return useMutation(apiTodos.deleteTodo, {
+    onSuccess: () => {
+      queryClient.invalidateQueries([...queryKeyGetTodos]);
+    },
+  });
 }
 
 export default useDeleteTodo;

--- a/src/screen/home/hooks/useGetTodoById.ts
+++ b/src/screen/home/hooks/useGetTodoById.ts
@@ -2,10 +2,12 @@ import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { apiTodos } from '../../../api/Todos/todos';
 import { ApiGetTodoById } from '../../../api/Todos/types';
 
+export const queryKeyGetTodoById = ['Todo', 'getOne'] as const;
+
 function useGetTodoById(todoId: string | undefined, option?: UseQueryOptions<ApiGetTodoById>) {
-  return useQuery<ApiGetTodoById>(['getTodoById', todoId], () => apiTodos.getTodoById(todoId), {
+  return useQuery<ApiGetTodoById>([...queryKeyGetTodoById, todoId], () => apiTodos.getTodoById(todoId), {
     enabled: !!todoId,
-    ...option
+    ...option,
   });
 }
 

--- a/src/screen/home/hooks/useGetTodos.ts
+++ b/src/screen/home/hooks/useGetTodos.ts
@@ -2,10 +2,10 @@ import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { apiTodos } from '../../../api/Todos/todos';
 import { ApiGetTodosResponse } from '../../../api/Todos/types';
 
-
+export const queryKeyGetTodos = ['Todo', 'getMany'] as const;
 
 function useGetTodos(options?: UseQueryOptions<ApiGetTodosResponse>) {
-  return useQuery<ApiGetTodosResponse>(['getTodos'], apiTodos.getTodos, options);
+  return useQuery<ApiGetTodosResponse>([...queryKeyGetTodos], apiTodos.getTodos, options);
 }
 
 export default useGetTodos;

--- a/src/screen/home/hooks/useUpdateTodo.ts
+++ b/src/screen/home/hooks/useUpdateTodo.ts
@@ -1,8 +1,13 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiTodos } from "../../../api/Todos/todos";
+import { queryKeyGetTodos } from "./useGetTodos";
 
 function useUpdateTodos() {
-  return useMutation(apiTodos.updateTodo);
+  const queryClient = useQueryClient()
+  return useMutation(apiTodos.updateTodo, {onSuccess: ()=>{
+    queryClient.invalidateQueries([...queryKeyGetTodos])
+
+  }});
 }
 
 export default useUpdateTodos

--- a/src/screen/home/template/TodoListTemplate.tsx
+++ b/src/screen/home/template/TodoListTemplate.tsx
@@ -32,14 +32,14 @@ const ListContainer = styled.ul`
 `;
 
 function TodoListTemplate() {
-  const { data: todosData, refetch: refetchTodos } = useGetTodos({ suspense: true });
+  const { data: todosData } = useGetTodos({ suspense: true });
 
   return (
     <TodoListContainer data-cy="container-todo-list">
       {todosData?.length ? (
         <ListContainer>
           {todosData.map((todo) => (
-            <TodoListCard key={todo.id} {...todo} refetchTodos={refetchTodos} />
+            <TodoListCard key={todo.id} {...todo}/>
           ))}
         </ListContainer>
       ) : (

--- a/src/screen/home/template/TodoWriteTemplate.tsx
+++ b/src/screen/home/template/TodoWriteTemplate.tsx
@@ -1,16 +1,13 @@
 import React from 'react';
 import { TodoParams } from '../../../api/Todos/types';
-import useGetTodos from '../hooks/useGetTodos';
 import useCreateTodo from '../hooks/useCreateTodo';
 import TodoWriteForm from '../component/TodoWriteForm';
 
 function TodoWriteTemplate() {
-  const { refetch: refetchTodos } = useGetTodos();
   const { mutate } = useCreateTodo();
 
   const saveTodoHandler = ({ title, content }: TodoParams, onSuccess: () => void) => {
     const onSuccessHandler = () => {
-      refetchTodos();
       onSuccess();
     };
 


### PR DESCRIPTION
query 관련 리팩토링 진행. #2 

1. 하드코딩 되어있던 query키를 변수로 관리하며 export시켜서 여러곳에 사용할 수 있게 하였습니다.
![image](https://user-images.githubusercontent.com/61589338/185334758-8526737c-a0c2-4a4d-88cc-b20c7e9ab4f2.png)

2. Todo를 수정하거나 삭제 할 경우 TodoList전체를 다시 불러와야 하는 반복적인 작업이 존재합니다. 이전에는, useGetTodos훅의 refetch를 이용하여 다시 불러오곤 했는데요, TanStack문서를 잘 읽어보니, queryClient의 invalideQueries메서드를 활용하면 쿼리 키를 활용하여 데이터를 update를 시킬 수 있었습니다. 해당 부분을 적용한 내용입니다.
![image](https://user-images.githubusercontent.com/61589338/185338099-0e5fbecb-d764-489a-9256-542f06792c25.png)

공식문서 링크 : https://tkdodo.eu/blog/mastering-mutations-in-react-query#invalidation