### PR TITLE
#3

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@hookform/resolvers": "^2.9.7",
     "@tanstack/react-query": "^4.0.10",
     "@tanstack/react-query-devtools": "^4.0.10",
     "@testing-library/jest-dom": "^5.14.1",
@@ -17,7 +18,8 @@
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.5",
-    "web-vitals": "^2.1.0"
+    "web-vitals": "^2.1.0",
+    "yup": "^0.32.11"
   },
   "scripts": {
     "start": "set PORT=3001 && react-scripts start",

--- a/src/common/constants/regex.ts
+++ b/src/common/constants/regex.ts
@@ -1,3 +1,0 @@
-
-export const emailPattern = /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
-export const passwordPattern = /^[A-Za-z0-9]{8,}$/;

--- a/src/screen/login/hooks/useLoginForm.ts
+++ b/src/screen/login/hooks/useLoginForm.ts
@@ -22,7 +22,7 @@ function useLoginForm() {
     resolver: yupResolver(schema),
   });
 
-  const isFormValid = () => {
+  const isFormNotValid = () => {
     return !!errors.email?.message || !!errors.password?.message;
   };
 
@@ -30,7 +30,7 @@ function useLoginForm() {
     trigger();
   }, []);
 
-  return { register, errors, handleSubmit, isFormValid };
+  return { register, errors, handleSubmit, isFormNotValid };
 }
 
 export default useLoginForm;

--- a/src/screen/login/hooks/useLoginForm.ts
+++ b/src/screen/login/hooks/useLoginForm.ts
@@ -1,0 +1,36 @@
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import * as yup from 'yup';
+import { LoginParams } from '../../../api/Auth/types';
+
+const schema = yup
+  .object({
+    email: yup.string().email().required(),
+    password: yup.string().min(8).required(),
+  })
+  .required();
+
+function useLoginForm() {
+  const {
+    register,
+    trigger,
+    formState: { errors },
+    handleSubmit,
+  } = useForm<LoginParams>({
+    mode: 'onChange',
+    resolver: yupResolver(schema),
+  });
+
+  const isFormValid = () => {
+    return !!errors.email?.message || !!errors.password?.message;
+  };
+
+  useEffect(() => {
+    trigger();
+  }, []);
+
+  return { register, errors, handleSubmit, isFormValid };
+}
+
+export default useLoginForm;

--- a/src/screen/login/hooks/useLoginForm.ts
+++ b/src/screen/login/hooks/useLoginForm.ts
@@ -6,8 +6,8 @@ import { LoginParams } from '../../../api/Auth/types';
 
 const schema = yup
   .object({
-    email: yup.string().email().required(),
-    password: yup.string().min(8).required(),
+    email: yup.string().email('이메일 양식이 올바르지 않습니다.').required(),
+    password: yup.string().min(8, '비밀번호는 8자리 이상입니다.').required(),
   })
   .required();
 
@@ -15,6 +15,8 @@ function useLoginForm() {
   const {
     register,
     trigger,
+    getValues,
+    watch,
     formState: { errors },
     handleSubmit,
   } = useForm<LoginParams>({
@@ -30,7 +32,10 @@ function useLoginForm() {
     trigger();
   }, []);
 
-  return { register, errors, handleSubmit, isFormNotValid };
+  const emailError = getValues('email') ? errors.email?.message : '';
+  const passwordError = watch('password') ? errors.password?.message : '';
+
+  return { register, emailError, passwordError, handleSubmit, isFormNotValid };
 }
 
 export default useLoginForm;

--- a/src/screen/login/hooks/useLoginMutation.ts
+++ b/src/screen/login/hooks/useLoginMutation.ts
@@ -2,8 +2,8 @@ import { useMutation } from '@tanstack/react-query';
 import { authApi } from '../../../api/Auth/auth';
 import { LoginError, LoginParams, LoginResponse } from '../../../api/Auth/types';
 
-function useLogin() {
+function useLoginMutation() {
   return useMutation<LoginResponse, LoginError, LoginParams>(authApi.login);
 }
 
-export default useLogin;
+export default useLoginMutation;

--- a/src/screen/login/template/LoginFormTemplate.tsx
+++ b/src/screen/login/template/LoginFormTemplate.tsx
@@ -21,7 +21,7 @@ export const LoginFormContainer = styled.form`
 
 function LoginFormTemplate() {
   const { mutate } = useLoginMutation();
-  const { register, handleSubmit, isFormValid } = useLoginForm();
+  const { register, handleSubmit, isFormNotValid } = useLoginForm();
 
   const loginRequest = ({ email, password }: LoginParams) => {
     const onSuccess = ({ token }: LoginResponse) => {
@@ -53,7 +53,7 @@ function LoginFormTemplate() {
         register={register('password')}
         placeholder="비밀번호를 입력해주세요."
       />
-      <ButtonBasic title="로그인" type="submit" data-cy="button-login" disabled={isFormValid()} />
+      <ButtonBasic title="로그인" type="submit" data-cy="button-login" disabled={isFormNotValid()} />
       <a className="link-join" href="/join" data-cy="link-join">
         회원가입하기
       </a>

--- a/src/screen/login/template/LoginFormTemplate.tsx
+++ b/src/screen/login/template/LoginFormTemplate.tsx
@@ -17,11 +17,22 @@ export const LoginFormContainer = styled.form`
   justify-content: space-around;
   align-items: center;
   padding: 20px;
+  .input-container {
+    width: 100%;
+    height: 50px;
+    .text-error {
+      display: block;
+      margin-top: 10px;
+      color: red;
+      font-size: 12px;
+      font-weight: bold;
+    }
+  }
 `;
 
 function LoginFormTemplate() {
   const { mutate } = useLoginMutation();
-  const { register, handleSubmit, isFormNotValid } = useLoginForm();
+  const { register, handleSubmit, isFormNotValid, emailError, passwordError } = useLoginForm();
 
   const loginRequest = ({ email, password }: LoginParams) => {
     const onSuccess = ({ token }: LoginResponse) => {
@@ -40,19 +51,26 @@ function LoginFormTemplate() {
   return (
     <LoginFormContainer onSubmit={handleSubmit(loginRequest)}>
       <span className="text-head">로그인</span>
-      <InputLabel
-        title="이메일"
-        register={register('email')}
-        data-cy="input-email"
-        placeholder="이메일을 입력해주세요."
-      />
-      <InputLabel
-        title="비밀번호"
-        data-cy="input-password"
-        type="password"
-        register={register('password')}
-        placeholder="비밀번호를 입력해주세요."
-      />
+      <div className="input-container">
+        <InputLabel
+          title="이메일"
+          register={register('email')}
+          data-cy="input-email"
+          placeholder="이메일을 입력해주세요."
+        />
+        {emailError && <span className="text-error">{emailError}</span>}
+      </div>
+      <div className="input-container">
+        <InputLabel
+          title="비밀번호"
+          data-cy="input-password"
+          type="password"
+          register={register('password')}
+          placeholder="비밀번호를 입력해주세요."
+        />
+        {passwordError && <span className="text-error">{passwordError}</span>}
+      </div>
+
       <ButtonBasic title="로그인" type="submit" data-cy="button-login" disabled={isFormNotValid()} />
       <a className="link-join" href="/join" data-cy="link-join">
         회원가입하기

--- a/src/screen/login/template/LoginFormTemplate.tsx
+++ b/src/screen/login/template/LoginFormTemplate.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { useForm } from 'react-hook-form';
 import styled from 'styled-components';
 import { LoginError, LoginParams, LoginResponse } from '../../../api/Auth/types';
 import ButtonBasic from '../../../common/components/button/ButtonBasic';
 import InputLabel from '../../../common/components/input/InputLabel';
-import { emailPattern, passwordPattern } from '../../../common/constants/regex';
 import { authTokenKey, persistStore } from '../../../persistStore/persistStore';
-import useLogin from '../hooks/useLogin';
+import useLoginMutation from '../hooks/useLoginMutation';
+import useLoginForm from '../hooks/useLoginForm';
 
 export const LoginFormContainer = styled.form`
   border: 2px solid gray;
@@ -21,9 +20,8 @@ export const LoginFormContainer = styled.form`
 `;
 
 function LoginFormTemplate() {
-  const { register, getValues, formState, handleSubmit } = useForm<LoginParams>({ mode: 'onChange' });
-
-  const { mutate } = useLogin();
+  const { mutate } = useLoginMutation();
+  const { register, handleSubmit, isFormValid } = useLoginForm();
 
   const loginRequest = ({ email, password }: LoginParams) => {
     const onSuccess = ({ token }: LoginResponse) => {
@@ -39,21 +37,12 @@ function LoginFormTemplate() {
     mutate({ email, password }, { onSuccess, onError });
   };
 
-  const isNotValild = () => {
-    return (
-      Boolean(formState.errors.email?.type) === true ||
-      Boolean(formState.errors.password?.type) === true ||
-      !getValues('email') ||
-      !getValues('password')
-    );
-  };
-
   return (
     <LoginFormContainer onSubmit={handleSubmit(loginRequest)}>
       <span className="text-head">로그인</span>
       <InputLabel
         title="이메일"
-        register={register('email', { pattern: emailPattern })}
+        register={register('email')}
         data-cy="input-email"
         placeholder="이메일을 입력해주세요."
       />
@@ -61,10 +50,10 @@ function LoginFormTemplate() {
         title="비밀번호"
         data-cy="input-password"
         type="password"
-        register={register('password', { pattern: passwordPattern })}
+        register={register('password')}
         placeholder="비밀번호를 입력해주세요."
       />
-      <ButtonBasic title="로그인" type="submit" data-cy="button-login" disabled={isNotValild()} />
+      <ButtonBasic title="로그인" type="submit" data-cy="button-login" disabled={isFormValid()} />
       <a className="link-join" href="/join" data-cy="link-join">
         회원가입하기
       </a>

--- a/src/screen/sign-up/hooks/useSignUpForm.ts
+++ b/src/screen/sign-up/hooks/useSignUpForm.ts
@@ -1,0 +1,30 @@
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useForm } from 'react-hook-form';
+import * as yup from 'yup';
+import { SignUpParams } from '../../../api/Auth/types';
+
+const schema = yup
+  .object({
+    email: yup.string().email().required(),
+    password: yup.string().min(8).required(),
+  })
+  .required();
+
+function useSignUpForm() {
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm<SignUpParams>({
+    mode: 'onChange',
+    resolver: yupResolver(schema),
+  });
+
+  const isFormValid = () => {
+    return !!errors.email?.message || !!errors.password?.message;
+  };
+
+  return { register, handleSubmit, isFormValid };
+}
+
+export default useSignUpForm;

--- a/src/screen/sign-up/hooks/useSignUpForm.ts
+++ b/src/screen/sign-up/hooks/useSignUpForm.ts
@@ -20,11 +20,11 @@ function useSignUpForm() {
     resolver: yupResolver(schema),
   });
 
-  const isFormValid = () => {
+  const isFormNotValid = () => {
     return !!errors.email?.message || !!errors.password?.message;
   };
 
-  return { register, handleSubmit, isFormValid };
+  return { register, handleSubmit, isFormNotValid };
 }
 
 export default useSignUpForm;

--- a/src/screen/sign-up/hooks/useSignUpForm.ts
+++ b/src/screen/sign-up/hooks/useSignUpForm.ts
@@ -5,8 +5,8 @@ import { SignUpParams } from '../../../api/Auth/types';
 
 const schema = yup
   .object({
-    email: yup.string().email().required(),
-    password: yup.string().min(8).required(),
+    email: yup.string().email('이메일 양식이 올바르지 않습니다.').required(),
+    password: yup.string().min(8, '비밀번호는 8자리 이상입니다.').required(),
   })
   .required();
 
@@ -15,6 +15,8 @@ function useSignUpForm() {
     register,
     formState: { errors },
     handleSubmit,
+    getValues,
+    watch,
   } = useForm<SignUpParams>({
     mode: 'onChange',
     resolver: yupResolver(schema),
@@ -24,7 +26,10 @@ function useSignUpForm() {
     return !!errors.email?.message || !!errors.password?.message;
   };
 
-  return { register, handleSubmit, isFormNotValid };
+  const emailError = getValues('email') ? errors.email?.message : '';
+  const passwordError = watch('password') ? errors.password?.message : '';
+
+  return { register, handleSubmit, emailError, passwordError, isFormNotValid };
 }
 
 export default useSignUpForm;

--- a/src/screen/sign-up/hooks/useSignUpMutation.ts
+++ b/src/screen/sign-up/hooks/useSignUpMutation.ts
@@ -2,8 +2,8 @@ import { useMutation } from '@tanstack/react-query';
 import { authApi } from '../../../api/Auth/auth';
 import { SignUpError, SignUpParams, SignUpResponse } from '../../../api/Auth/types';
 
-function useSignUp() {
+function useSignUpMutation() {
   return useMutation<SignUpResponse, SignUpError, SignUpParams>(authApi.join);
 }
 
-export default useSignUp;
+export default useSignUpMutation;

--- a/src/screen/sign-up/template/SignUpFormTemplate.tsx
+++ b/src/screen/sign-up/template/SignUpFormTemplate.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { SignUpError, SignUpParams, SignUpResponse } from '../../../api/Auth/types';
 import InputLabel from '../../../common/components/input/InputLabel';
 import ButtonBasic from '../../../common/components/button/ButtonBasic';
-import { emailPattern, passwordPattern } from '../../../common/constants/regex';
 import { persistStore } from '../../../persistStore/persistStore';
 import useSignUpMutation from '../hooks/useSignUpMutation';
 import useSignUpForm from '../hooks/useSignUpForm';
@@ -58,7 +57,7 @@ function SignUpFormTemplate() {
       <div className="input-container">
         <InputLabel
           title="이메일"
-          register={register('email', { pattern: emailPattern })}
+          register={register('email')}
           data-cy="input-email"
           placeholder="이메일을 입력해주세요."
         />
@@ -69,7 +68,7 @@ function SignUpFormTemplate() {
           title="비밀번호"
           data-cy="input-password"
           type="password"
-          register={register('password', { pattern: passwordPattern })}
+          register={register('password')}
           placeholder="비밀번호를 입력해주세요."
         />
         {passwordError && <span className="text-error">{passwordError}</span>}

--- a/src/screen/sign-up/template/SignUpFormTemplate.tsx
+++ b/src/screen/sign-up/template/SignUpFormTemplate.tsx
@@ -25,7 +25,7 @@ function SignUpFormTemplate() {
   const navigate = useNavigate();
 
   const { mutate } = useSignUpMutation();
-  const { register, handleSubmit, isFormValid } = useSignUpForm();
+  const { register, handleSubmit, isFormNotValid } = useSignUpForm();
 
   const signUpRequest = ({ email, password }: SignUpParams) => {
     const onSuccess = ({ token }: SignUpResponse) => {
@@ -57,7 +57,7 @@ function SignUpFormTemplate() {
         register={register('password', { pattern: passwordPattern })}
         placeholder="비밀번호를 입력해주세요."
       />
-      <ButtonBasic title="회원가입" disabled={isFormValid()} type="submit" data-cy="button-join" />
+      <ButtonBasic title="회원가입" disabled={isFormNotValid()} type="submit" data-cy="button-join" />
       <a className="link-join" href="/" data-cy="link-login">
         로그인하기
       </a>

--- a/src/screen/sign-up/template/SignUpFormTemplate.tsx
+++ b/src/screen/sign-up/template/SignUpFormTemplate.tsx
@@ -3,11 +3,11 @@ import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import React from 'react';
 import { SignUpError, SignUpParams, SignUpResponse } from '../../../api/Auth/types';
-import useSignUp from '../hooks/useSignUp';
 import InputLabel from '../../../common/components/input/InputLabel';
 import ButtonBasic from '../../../common/components/button/ButtonBasic';
 import { emailPattern, passwordPattern } from '../../../common/constants/regex';
 import { persistStore } from '../../../persistStore/persistStore';
+import useSignUpMutation from '../hooks/useSignUpMutation';
 
 export const SignUpFormContainer = styled.form`
   border: 2px solid gray;
@@ -25,7 +25,7 @@ function SignUpFormTemplate() {
   const { register, getValues, formState, handleSubmit } = useForm<SignUpParams>({ mode: 'onChange' });
   const navigate = useNavigate();
 
-  const { mutate } = useSignUp();
+  const { mutate } = useSignUpMutation();
 
   const signUpRequest = ({ email, password }: SignUpParams) => {
     const onSuccess = ({ token }: SignUpResponse) => {

--- a/src/screen/sign-up/template/SignUpFormTemplate.tsx
+++ b/src/screen/sign-up/template/SignUpFormTemplate.tsx
@@ -19,13 +19,24 @@ export const SignUpFormContainer = styled.form`
   justify-content: space-around;
   align-items: center;
   padding: 20px;
+  .input-container {
+    width: 100%;
+    height: 50px;
+    .text-error {
+      display: block;
+      margin-top: 10px;
+      color: red;
+      font-size: 12px;
+      font-weight: bold;
+    }
+  }
 `;
 
 function SignUpFormTemplate() {
   const navigate = useNavigate();
 
   const { mutate } = useSignUpMutation();
-  const { register, handleSubmit, isFormNotValid } = useSignUpForm();
+  const { register, handleSubmit, isFormNotValid, emailError, passwordError } = useSignUpForm();
 
   const signUpRequest = ({ email, password }: SignUpParams) => {
     const onSuccess = ({ token }: SignUpResponse) => {
@@ -44,19 +55,25 @@ function SignUpFormTemplate() {
   return (
     <SignUpFormContainer onSubmit={handleSubmit(signUpRequest)}>
       <span className="text-head">회원가입</span>
-      <InputLabel
-        title="이메일"
-        register={register('email', { pattern: emailPattern })}
-        data-cy="input-email"
-        placeholder="이메일을 입력해주세요."
-      />
-      <InputLabel
-        title="비밀번호"
-        data-cy="input-password"
-        type="password"
-        register={register('password', { pattern: passwordPattern })}
-        placeholder="비밀번호를 입력해주세요."
-      />
+      <div className="input-container">
+        <InputLabel
+          title="이메일"
+          register={register('email', { pattern: emailPattern })}
+          data-cy="input-email"
+          placeholder="이메일을 입력해주세요."
+        />
+        {emailError && <span className="text-error">{emailError}</span>}
+      </div>
+      <div className="input-container">
+        <InputLabel
+          title="비밀번호"
+          data-cy="input-password"
+          type="password"
+          register={register('password', { pattern: passwordPattern })}
+          placeholder="비밀번호를 입력해주세요."
+        />
+        {passwordError && <span className="text-error">{passwordError}</span>}
+      </div>
       <ButtonBasic title="회원가입" disabled={isFormNotValid()} type="submit" data-cy="button-join" />
       <a className="link-join" href="/" data-cy="link-login">
         로그인하기

--- a/src/screen/sign-up/template/SignUpFormTemplate.tsx
+++ b/src/screen/sign-up/template/SignUpFormTemplate.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import React from 'react';
 import { SignUpError, SignUpParams, SignUpResponse } from '../../../api/Auth/types';
@@ -8,6 +7,7 @@ import ButtonBasic from '../../../common/components/button/ButtonBasic';
 import { emailPattern, passwordPattern } from '../../../common/constants/regex';
 import { persistStore } from '../../../persistStore/persistStore';
 import useSignUpMutation from '../hooks/useSignUpMutation';
+import useSignUpForm from '../hooks/useSignUpForm';
 
 export const SignUpFormContainer = styled.form`
   border: 2px solid gray;
@@ -22,10 +22,10 @@ export const SignUpFormContainer = styled.form`
 `;
 
 function SignUpFormTemplate() {
-  const { register, getValues, formState, handleSubmit } = useForm<SignUpParams>({ mode: 'onChange' });
   const navigate = useNavigate();
 
   const { mutate } = useSignUpMutation();
+  const { register, handleSubmit, isFormValid } = useSignUpForm();
 
   const signUpRequest = ({ email, password }: SignUpParams) => {
     const onSuccess = ({ token }: SignUpResponse) => {
@@ -39,15 +39,6 @@ function SignUpFormTemplate() {
       return response?.data && window.alert(response?.data.details);
     };
     mutate({ email, password }, { onSuccess, onError });
-  };
-
-  const isNotValild = () => {
-    return (
-      Boolean(formState.errors.email?.type) === true ||
-      Boolean(formState.errors.password?.type) === true ||
-      !getValues('email') ||
-      !getValues('password')
-    );
   };
 
   return (
@@ -66,7 +57,7 @@ function SignUpFormTemplate() {
         register={register('password', { pattern: passwordPattern })}
         placeholder="비밀번호를 입력해주세요."
       />
-      <ButtonBasic title="회원가입" disabled={isNotValild()} type="submit" data-cy="button-join" />
+      <ButtonBasic title="회원가입" disabled={isFormValid()} type="submit" data-cy="button-join" />
       <a className="link-join" href="/" data-cy="link-login">
         로그인하기
       </a>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1030,7 +1030,7 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
   integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
@@ -1246,6 +1246,11 @@
     js-yaml "^4.1.0"
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
+
+"@hookform/resolvers@^2.9.7":
+  version "2.9.7"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-2.9.7.tgz#8b257ae67234ce0270e6b044c1a61fb98ec02b4b"
+  integrity sha512-BloehX3MOLwuFEwT4yZnmolPjVmqyn8VsSuodLfazbCIqxBHsQ4qUZsi+bvNNCduRli1AGWFrkDLGD5QoNzsoA==
 
 "@humanwhocodes/config-array@^0.10.4":
   version "0.10.4"
@@ -2021,6 +2026,11 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
+
+"@types/lodash@^4.14.175":
+  version "4.14.183"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.183.tgz#1173e843e858cff5b997c234df2789a4a54c2374"
+  integrity sha512-UXavyuxzXKMqJPEpFPri6Ku5F9af6ZJXUneHhvQJxavrEjuHkFp2YnDWHcxJiG7hk8ZkWqjcyNeW1s/smZv5cw==
 
 "@types/mime@*":
   version "3.0.0"
@@ -6514,6 +6524,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -6758,6 +6773,11 @@ multicast-dns@^7.2.5:
   dependencies:
     dns-packet "^5.2.2"
     thunky "^1.0.2"
+
+nanoclone@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
+  integrity sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
 
 nanoid@^3.3.4:
   version "3.3.4"
@@ -7820,6 +7840,11 @@ prop-types@^15.7.2, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+property-expr@^2.0.4:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.5.tgz#278bdb15308ae16af3e3b9640024524f4dc02cb4"
+  integrity sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==
 
 proxy-addr@~2.0.7:
   version "2.0.7"
@@ -9119,6 +9144,11 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
+
 tough-cookie@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.0.0.tgz#d822234eeca882f991f0f908824ad2622ddbece4"
@@ -9908,3 +9938,16 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yup@^0.32.11:
+  version "0.32.11"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.32.11.tgz#d67fb83eefa4698607982e63f7ca4c5ed3cf18c5"
+  integrity sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@types/lodash" "^4.14.175"
+    lodash "^4.17.21"
+    lodash-es "^4.17.21"
+    nanoclone "^0.2.1"
+    property-expr "^2.0.4"
+    toposort "^2.0.2"


### PR DESCRIPTION
# Form Validation regex -> Yup #3

## 주요 변경사항.
1. regex를 적용한 validation을 yup으로 교체.(yup이 훨씬 선언적이고, 이해가 쉬움.)

2. useForm함수를 사용하는 custom hook 적용. (useLoginForm, useSignUpForm)

3. useLogin, useSignUp네이밍 변경. (useLogin -> useLoginMutation)

4. 입력값 validation후 에러메세지 표현.

## 수정 내용
### regex를 yup으로 교체.

처음에 joi로 하려고 했으나, 비교 자료를 보고 yup을 선정했습니다.
yup은 typescript라이브러리이고, 용량도 더 작기 때문에 yup 이 더 적절한 라이브러리인것 같습니다.
비교 자료 : https://npmtrends.com/joi-vs-yup

적용 결과.
```
// before
export const emailPattern = /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
// after
 email: yup.string().email('이메일 양식이 올바르지 않습니다.').required(),
```
yup을 이용해서 email에 대한 검증을 간결하게 하고, react hook form과 연계하여 에러메세지도 포함 시켜줄 수 있다.

### useForm함수를 custom hook으로 만들어서 사용.
![image](https://user-images.githubusercontent.com/61589338/185400205-96c1bcc4-90dd-4c5c-899d-f16299a3c2c3.png)
useForm함수가 비대해지고, validation관련 로직이 증가함에 따라, custom hook으로 만들었습니다.

```
// before
 const { register, getValues, formState, handleSubmit } = useForm<LoginParams>({ mode: 'onChange' });
// after
const { register, handleSubmit, isFormNotValid, emailError, passwordError } = useLoginForm();
```
view단의 코드가 더 간결해지고, 기타 validation 로직도 함께 추상화 할 수 있었습니다.

### useLogin 네이밍 변경.
![image](https://user-images.githubusercontent.com/61589338/185400744-36f37c84-c559-499d-a697-82c7014fc676.png)
useLogin이라는 이름은 useLoginForm이 작성되기 전에는 그럭저럭 괜찮은 이름이었습니다.
하지만 useLoginForm이 추가됨에 따라, 이름이 모호하게 느껴지고, 기능을 오해할 가능성이 있다고 생각되어 useLogin에서 useLoginMutation으로 이름을 바꾸었습니다.

### 에러메시지 적용
![image](https://user-images.githubusercontent.com/61589338/185401466-4dc206f2-1b9e-471e-b774-432ea0c234ad.png)
사용자에게 유효한 입력의 기준을 고지하여 UX를 개선하였습니다.